### PR TITLE
fix 'np.float/np.complex depreciated'

### DIFF
--- a/spike/File/Solarix.py
+++ b/spike/File/Solarix.py
@@ -238,8 +238,11 @@ def Import_2D(folder, outfile = "", F1specwidth = None, compress=False):
     parfilename = locate_acquisition(folder)
     params = read_param(parfilename)
     
-    # Import parameters : size in F1 and F2    
-    sizeF1 = read_scan(os.path.join(folder,"scan.xml"))
+    # Import parameters : size in F1 and F2
+    try:
+        sizeF1 = read_scan(os.path.join(folder,"scan.xml"))
+    except FileNotFoundError:
+        sizeF1 = read_scan(os.path.join(folder,"ImagingInfo.xml"))
 #    sizeF1 = int(params["L_20"]) #CR Not working if L_20 higher than 16383 
     sizeF2 = int(params["TD"])
 

--- a/spike/NPKData.py
+++ b/spike/NPKData.py
@@ -84,7 +84,7 @@ def conj_ip(a):
     >>> conj_ip(np.arange(4)*(1+1j))
     [ 0.-0.j  1.-1.j  2.-2.j  3.-3.j]
     """
-    if a.dtype == np.complex:
+    if a.dtype == complex:
         b = as_float(a)[1::2]       # create a view of the imaginary part of a
         np.multiply(b,-1.0,b)       # and inverse it on-place
 #        b *= -1.0                  # is equivalent
@@ -819,8 +819,8 @@ class _NPKData(object):
         try:                # pbs may appear with pytables buffer
             dt = buff.dtype
         except:
-            dt = np.float
-        if dt == np.complex:
+            dt = float
+        if dt == complex:
             buff = as_float(buff)
             self.axes(self.dim).itype = 1
         elif dt == 'float':
@@ -969,8 +969,8 @@ class _NPKData(object):
         try:
             dt = self.buffer.dtype
         except:
-            dt = np.float
-        if dt != np.float:
+            dt = float
+        if dt != float:
             check_msg("wrong buffer type : %s"%str(dt))
         if len(self.buffer.shape) != self.dim:
             check_msg("wrong dim value : %d while buffer is %d"%(self.dim,len(self.buffer.shape)))


### PR DESCRIPTION
- These aliases have been depreciated for the builtin types since NumPy 1.20.
- The machine we have produces file name 'ImagingInfo.xml' instead of 'scan.xml' 